### PR TITLE
I am bringing back default location for a based Docker image

### DIFF
--- a/imasdb-token.ini
+++ b/imasdb-token.ini
@@ -1,10 +1,10 @@
 [example]
 glob = /home/imas/public/imasdb
 recursive = True
-action = /home/imas/imas-watchdog/handler-imasdb.py
+action = /imas-watchdog/handler-imasdb.py
 duration = 5
 
-jar = /home/imas/catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
+jar = /catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
 ; debug = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:32887'
 disable-access-token = True
 url = http://server:8080

--- a/imasdb.ini
+++ b/imasdb.ini
@@ -1,8 +1,8 @@
 [example]
 glob = /home/imas/public/imasdb
 recursive = True
-action = /home/imas/imas-watchdog/handler-imasdb.py
+action = /imas-watchdog/handler-imasdb.py
 duration = 5
 
-jar = /home/imas/catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
+jar = /catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
 url = http://server:8080


### PR DESCRIPTION
We have to use the original location for py files and catalog_qt_2 - otherwise, default setup doesn't work.